### PR TITLE
Very minor change to crew management

### DIFF
--- a/internal_comms/crew_management.mast
+++ b/internal_comms/crew_management.mast
@@ -29,7 +29,11 @@ set_inventory_value(SPAWNED_ID, "max_crew_size", crew_size)
 +"Back" //comms
 +"Crew status":
     crew_size = COMMS_ORIGIN["crew_size"] #| 0
+    if crew_size == None:
+        crew_size = 0
     dead = COMMS_ORIGIN["casulaty_count"] # | 0
+    if dead == None:
+        dead = 0
     <<[$sickbay] "sickbay crew health"
         " Currently we have {crew_size} healthy crew members and {dead} casualties
 


### PR DESCRIPTION
The Sickbay -> Crew Status button resulted in "Currently we have 250 healthy crew members and None casualties. This commit changes "None" to "0".

Question:
In crew_management.mast, why is `COMMS_ORIGIN["crew_size"]` used instead of 
```get_inventory_value(COMMS_ORIGIN_ID, "crew_size", 0)```?
Are they interchangeable?