### PR TITLE
Fixes for #306, #302, #268, and #259

### DIFF
--- a/collisions/collision.mast
+++ b/collisions/collision.mast
@@ -13,7 +13,7 @@
     cur_speed = to_engine_object(playerObj).cur_speed
 
     # Scales with speed, difficulty, and TODO: the size of the asteroid
-    base_damage = cur_speed * DIFFICULTY
+    base_damage = abs(cur_speed) * DIFFICULTY
     damage = base_damage
     print("Passive Collision, Current Speed: " + str(cur_speed))
     print("Passive Collision, Difficulty: " + str(DIFFICULTY))

--- a/comms/enemy_surrender.mast
+++ b/comms/enemy_surrender.mast
@@ -8,7 +8,7 @@ shared _surrender_return = task_schedule(take_surrendered_home)
     yield fail if has_role(COMMS_SELECTED_ID, "surrendered")
 
     surrender_count = get_inventory_value(COMMS_SELECTED_ID, "surrender_count", 0)
-    hide_surr = surrender_count >= 3
+    hide_surr = surrender_count >= 4
     #
     # Secret code case
     #
@@ -32,9 +32,16 @@ shared _surrender_return = task_schedule(take_surrendered_home)
     ->END if player is None
     name = player.name
     surrender_count = get_inventory_value(COMMS_SELECTED_ID, "surrender_count", 0)
-    set_inventory_value(COMMS_SELECTED_ID, "surrender_count", surrender_count+1)
 
+    # Secret Codecase, force surrender if active, otherwise check shield ratio
     sc_timer = get_inventory_value(COMMS_ORIGIN_ID, "sc_timer", 0)
+    if sc_timer > 0:
+        sc_timer = 0
+        set_inventory_value(COMMS_ORIGIN_ID, "sc_timer", sc_timer )
+        await task_schedule(comms_do_surrender)
+        ->END
+
+    # get lowest shield value
     shield_count = blob.get("shield_count", 0)
     ->END if shield_count is None
     s_ratio = 100
@@ -43,27 +50,67 @@ shared _surrender_return = task_schedule(take_surrendered_home)
         s_cur = blob.get("shield_val", s )
         s_ratio = min(s_cur/s_max, s_ratio)
 
-    # Secret Codecase, force surrender if active, otherwise check shield ratio
-    if sc_timer > 0:
-        sc_timer = 0
-        set_inventory_value(COMMS_ORIGIN_ID, "sc_timer", sc_timer )
-        await task_schedule(comms_do_surrender)
-        
+    s_chance = random.randint(1,100)
+    s_crew = to_object(COMMS_SELECTED_ID).crew
+
+    print("Surrender Attempt")
+    print("Shield Ratio: " + str(s_ratio))
+    print("Surrender Chance: " + str(s_chance))
+    print("Surrender Crew: " + str(s_crew))
+    s_mod = 0
+    if s_crew == "arvonian": # Arvonian nobolity prides itself on honor and valor, and detests cowardice
+        s_mod = 5  
+    if s_crew == "skaraan": # Surrendering is bad for business 
+        s_mod = 10
+    if s_crew == "kralien": # Kralien ships tend to be underpowered and outgunned
+        s_mod = -15
+    if s_crew == "torgoth": # Torgoth are xenophobic and less likely to surrender to an "inferior" race
+        s_mod = 15
+    if s_crew == "ximni": # Meaningless death is not considered to be in the spirit of "Xim"
+        s_mod = -10
+    print("Crew Modifier: " + str(s_mod))
+    s_chance = s_chance + s_mod
+    print("Difficulty Modifier: " + str(DIFFICULTY * 2))
+    s_chance = s_chance + (DIFFICULTY * 2)
+    print("Modified Chance: " + str(s_chance))
+
+    if s_ratio >= 0.5:
+          comms_receive(f"""Go climb a tree, {name}!""", title="failed surrender", title_color=raider_color)
+    elif s_ratio < 0.5 and s_ratio >= 0.09:
+        if s_chance <= 40:
+            await task_schedule(comms_do_surrender)
+        else:
+            comms_receive(f"""We can still defeat you, {name}! Prepare to die!""", title="Surrender ignored", title_color=raider_color)
     elif s_ratio < 0.09:
-        if random.randint(1,6)<3:
+        if s_chance <= 75:
             await task_schedule(comms_do_surrender)
         else:
             comms_receive(f"""We will fight to our last breath!""", title="failed surrender", title_color=raider_color)
             add_role(COMMS_SELECTED_ID, "never_surrender")
 
-    elif s_ratio < 0.5:
-        if random.randint(0,6)<=2:
-            await task_schedule(comms_do_surrender)
-        else:
-            comms_receive(f"""We can still defeat you, {name}! Prepare to die!""", title="Surrender ignored", title_color=raider_color)
+    # Chance that a surrender attempt doesn't "count" towards the limit (currently 3 max)
+    # At higher difficulty, chance is lower. 
+    if random.randint(1,100) <= (60 - DIFFICULTY * 4):    
+        set_inventory_value(COMMS_SELECTED_ID, "surrender_count", surrender_count+1)
+    surrender_count = get_inventory_value(COMMS_SELECTED_ID, "surrender_count", 0)
+    print("Surrender Count: " + str(surrender_count))
 
-    else:
-        comms_receive(f"""Go climb a tree, {name}!""", title="failed surrender", title_color=raider_color)
+#    if s_ratio < 0.09:
+#        if s_chance <= 75:
+#            await task_schedule(comms_do_surrender)
+#        else:
+#            comms_receive(f"""We will fight to our last breath!""", title="failed surrender", title_color=raider_color)
+#            add_role(COMMS_SELECTED_ID, "never_surrender")
+#
+#    elif s_ratio < 0.5:
+#        if random.randint(1,100)<=40:
+#            await task_schedule(comms_do_surrender)
+#        else:
+#            comms_receive(f"""We can still defeat you, {name}! Prepare to die!""", title="Surrender ignored", title_color=raider_color)
+#
+#    else:
+#        comms_receive(f"""Go climb a tree, {name}!""", title="failed surrender", title_color=raider_color)
+
     comms_navigate("//comms")
     yield success
 
@@ -75,7 +122,8 @@ shared _surrender_return = task_schedule(take_surrendered_home)
     comms_receive(f"""OK we give up, {name}.""", title_color=surrender_color)
     add_role(COMMS_SELECTED_ID, "surrendered")
     surrender = game_stats.get("ships_surrender", 0 )
-    surrender += 1
+    if random.randint(1,100)<=50:
+        surrender += 1
     game_stats["ships_surrender"] = surrender
     remove_role(COMMS_SELECTED_ID, "raider")
     set_data_set_value(COMMS_SELECTED_ID, "surrender_flag", 1)

--- a/maps/peacetime.mast
+++ b/maps/peacetime.mast
@@ -111,7 +111,7 @@ Properties:
     spawn_points = scatter.box(5, 0, 0, 0, 50000, 1000, 50000, centered=True)
     for c in spawn_points:
         # First three suspects have "California" names
-        if s_count >= 1 and s_count <= 3:    
+        if s_count >= 1 and s_count <= 3:
             cargo_name = random.choice(alpha) + str(random.randint(1,99)).zfill(2) + " " + peacetime_list.pop(random.randint(0,len(peacetime_list)-1))
             c_ship = to_id(npc_spawn(*c, cargo_name, "civ, civilian, suspect", "cargo_ship", "behav_npcship"))
         # Last two suspects have "Civilian" names
@@ -816,11 +816,11 @@ yield success
 
 ===== kidnap_message =====
     await delay_sim(15)
-    for p in role("__player__"):
-        if p is not None:
-            send_general_message("Admiral Harkin", "Ambassador Florbin has been kidnapped! Contact DS1 for details.", admiral_face, p)
+    ds1_list = to_list(role("ds1"))
+    ->END if len(ds1_list) < 1
+    ds1_id = ds1_list[0]
+    send_general_message("Admiral Harkin", "Ambassador Florbin has been kidnapped! Contact DS1 for details.", admiral_face, ds1_id)
     ->END
-
 
 ===== scanning_cargo_containers ======
 
@@ -969,9 +969,9 @@ yield success
 
 
 ===== check_ambassador_rescued ======
-
     for p in role("__player__"):
         ds1_list = to_list(role("ds1"))
+        ->END if len(ds1_list) < 1
         ds1_id = ds1_list[0]
         dist = sbs.distance_id(p, ds1_id)
         p_obj = to_object(p)
@@ -979,7 +979,7 @@ yield success
         check_pod = get_inventory_value(p, "escape-pod", 0)
         if dock_status == "docked" and dist <= 600 and check_pod > 0:
             #admiral_face = "ter #964b00 8 1;ter #968b00 3 0;ter #968b00 4 0;ter #968b00 5 2;ter #fff 4 4;ter #964b00 8 4;"
-            send_general_message("Admiral Harkin", "Ambassador Florbin has been safely delivered back to DS 1! Well done, " + p_obj.name + "!", admiral_face, p)
+            send_general_message("Admiral Harkin", "Ambassador Florbin has been safely delivered back to DS 1! Well done, " + p_obj.name + "!", admiral_face, ds1_id)
             #comms_message(f"Ambassador Florbin has been safely delivered back to DS 1. Well done, {p_obj.name}!", ds1_id, p, title="Ambassador Rescued", title_color="green")
             kidnap_status = 5
             ->END


### PR DESCRIPTION
collision fix for "back into asteroid gives massive boost to rear shields"
reworked a big chunk of the surrender code so "We will fight to the last breath!" isn't so common. Surrender chance now includes modifiers for "crew" (races) and DIFFICULTY, and there's a chance the surrender_count does not increase, allowing more surrender attempts (max limit increased to 3 instead of 2).
Fixed a few bugs in Peacetime, no longer crashes if DS1 destroyed, and duplicate messages should be fixed now.