### PR TITLE
Adding Navproxies to Deep Strike and Border War

### DIFF
--- a/collisions/collision.mast
+++ b/collisions/collision.mast
@@ -1,6 +1,11 @@
 # For passive collision, players are the TARGET_ID and SELECTED_ID
 # SOURCE_ID and ORIGIN_ID are the other thing
 //collision/passive if has_role(COLLISION_TARGET_ID, "__player__")
+
+    if has_role(COLLISION_SOURCE_ID, "black_hole"):
+        explode_player_ship(COLLISION_TARGET_ID)
+        ->END
+
     player = COLLISION_TARGET_ID
     passive = COLLISION_SOURCE_ID
 

--- a/damage/destroy.mast
+++ b/damage/destroy.mast
@@ -13,7 +13,11 @@
             % The enemy have over run us. We're doomed.
             % Remember us....<static>
         
-
+//damage/destroy if has_roles(DESTROYED_ID, "delprox,station") 
+    nav_id = get_inventory_value(DESTROYED_ID, "navprox_id", 0)
+    print("Station Destroyed, Deleting Navproxy:")
+    print(nav_id)
+    sim.delete_navproxy_by_id(nav_id)
 
 
 //damage/killed if has_role(DAMAGE_SELECTED_ID, "raider")

--- a/maps/borderwar.mast
+++ b/maps/borderwar.mast
@@ -122,15 +122,14 @@ Properties:
         name = "{station_prefix} {index+1}"
 
         if enemy1 == "Kralien":
-            enemy_station_object = npc_spawn(*pos, name, "kralien, enemy, station", station_type, "behav_station")
+            enemy_station_object = npc_spawn(*pos, name, "raider, kralien, delprox, enemy, station", station_type, "behav_station")
         if enemy1 == "Torgoth":
-            enemy_station_object = npc_spawn(*pos, name, "torgoth, enemy, station", station_type, "behav_station")
+            enemy_station_object = npc_spawn(*pos, name, "raider, torgoth, delprox, enemy, station", station_type, "behav_station")
         if enemy1 == "Arvonian":
-            enemy_station_object = npc_spawn(*pos, name, "arvonian, enemy, station", station_type, "behav_station")
-        nav_id = sim.add_navpoint(*pos, name, "#A44")
-        enemy_station_list.append(to_id(enemy_station_object))
-        navpoint_list.append(nav_id)
-        enemy_station_dict[to_id(enemy_station_object)] = nav_id
+            enemy_station_object = npc_spawn(*pos, name, "raider, arvonian, delprox, enemy, station", station_type, "behav_station")
+        eso_id = to_id(enemy_station_object)
+        nav_obj = sim.add_navproxy(eso_id, name, station_type, "#A44")
+        set_inventory_value(eso_id, "navprox_id", to_id(nav_obj))
 
         if enemy1 == "Kralien":
             set_face(to_id(enemy_station_object), random_kralien())

--- a/maps/deepstrike.mast
+++ b/maps/deepstrike.mast
@@ -80,9 +80,10 @@ Properties:
     # Build enemy stations, generate fleets
 
 
-    enemy_station_list = []
-    navpoint_list = []
-    enemy_station_dict = {}
+#    enemy_station_list = []
+#    navpoint_list = []
+#    navproxy_list = []
+#    enemy_station_dict = {}
 
     pos = Vec3()
     startZ = -50000
@@ -117,15 +118,14 @@ Properties:
         name = "{station_prefix} {index+1}"
 
         if enemy1 == "Kralien":
-            enemy_station_object = npc_spawn(*pos, name, "kralien, enemy, station", station_type, "behav_station")
+            enemy_station_object = npc_spawn(*pos, name, "raider, kralien, enemy, delprox, station", station_type, "behav_station")
         if enemy1 == "Torgoth":
-            enemy_station_object = npc_spawn(*pos, name, "torgoth, enemy, station", station_type, "behav_station")
+            enemy_station_object = npc_spawn(*pos, name, "raider, torgoth, enemy, delprox, station", station_type, "behav_station")
         if enemy1 == "Arvonian":
-            enemy_station_object = npc_spawn(*pos, name, "arvonian, enemy, station", station_type, "behav_station")
-        nav_id = sim.add_navpoint(*pos, name, "#A44")
-        enemy_station_list.append(to_id(enemy_station_object))
-        navpoint_list.append(nav_id)
-        enemy_station_dict[to_id(enemy_station_object)] = nav_id
+            enemy_station_object = npc_spawn(*pos, name, "raider, arvonian, enemy, delprox, station", station_type, "behav_station")
+        eso_id = to_id(enemy_station_object)
+        nav_obj = sim.add_navproxy(eso_id, name, station_type, "#A44")
+        set_inventory_value(eso_id, "navprox_id", to_id(nav_obj))
 
         if enemy1 == "Kralien":
             set_face(to_id(enemy_station_object), random_kralien())

--- a/maps/watch_for_end.mast
+++ b/maps/watch_for_end.mast
@@ -66,12 +66,14 @@
 
     # Check to see if any stations no longer exist. If so, delete the navpoint associated with that station.
 
-    if len(stations) >= 1:
-        for i in range(len(enemy_station_dict)):
-            station_id = enemy_station_list[i]
-            nav_id = enemy_station_dict[station_id]
-            if not object_exists(station_id) and nav_id in navpoint_list:
-                sim.delete_navpoint_by_id(nav_id)
+#    if len(stations) >= 1:
+#        for i in range(len(enemy_station_dict)):
+#            station_id = enemy_station_list[i]
+#            nav_id = navproxy_list[i]
+#            print(station_id)
+#            print(nav_id)
+#            if not object_exists(station_id) and nav_id in navproxy_list:
+#               sim.delete_navproxy_by_id(nav_id)
 
     # If all enemies and enemy stations have been destroyed, mission succeeds and game ends.
 
@@ -146,13 +148,13 @@
 
     # Check to see if any enemy stations no longer exist. If so, delete the navpoint associated with that station.
 
-    if len(stations) >= 1:
-        for i in range(len(enemy_station_dict)):
-            station_id = enemy_station_list[i]
-            nav_id = enemy_station_dict[station_id]
-            if not object_exists(station_id) and nav_id in navpoint_list:
-                sim.delete_navpoint_by_id(nav_id)
-                navpoint_list.remove(nav_id)
+#    if len(stations) >= 1:
+#        for i in range(len(enemy_station_dict)):
+#            station_id = enemy_station_list[i]
+#            nav_id = enemy_station_dict[station_id]
+#            if not object_exists(station_id) and nav_id in navpoint_list:
+#                sim.delete_navpoint_by_id(nav_id)
+#                navpoint_list.remove(nav_id)
 
     # If all enemy raiders and enemy stations have been destroyed, mission succeeds and game ends.
 


### PR DESCRIPTION
Collision fix for black holes. 
destroy.mast checks for delprox role on stations, deletes navproxy if station destroyed
Deep Strike: Adds "raider" and "delprox" roles to enemy stations
Border War: Adds "raider" and "delprox" roles to enemy stations
watch_for_end.mast: comment out loop to check for destroyed stations 