### PR TITLE
Torpedo rework

### DIFF
--- a/comms/station_weapon_building.mast
+++ b/comms/station_weapon_building.mast
@@ -71,6 +71,8 @@ shared surrender_color = "yellow"
     stats = ""
     for t in torp_keys:
         count = get_data_set_value(COMMS_SELECTED_ID, f"{t}_NUM", 0)
+        if count is None:
+            count = 0
         time = get_build_time_for(COMMS_SELECTED_ID, t)
         stats += """ ^{t: <10}{count: >5}{"": >16}{time}:00"""
 
@@ -125,6 +127,8 @@ shared surrender_color = "yellow"
 
 
     cur_count = get_data_set_value(station_id, f"{torpedo_build_type}_NUM", 0)
+    if cur_count is None:
+        cur_count = 0
     set_data_set_value(station_id, f"{torpedo_build_type}_NUM", cur_count+1, 0)
 
     side = station.side

--- a/comms/station_weapon_building.mast
+++ b/comms/station_weapon_building.mast
@@ -30,11 +30,14 @@ shared surrender_color = "yellow"
 //comms/station/build
     comms_id = COMMS_ORIGIN.name
     + !0 "Back" //comms
-    + "Build Homing" station_build_weapon {"build_type": "Homing", "comms_id": comms_id, "weapon_text": "Homing"}
-    + "Build Nuke" station_build_weapon {"build_type": "Nuke", "comms_id": comms_id, "weapon_text": "Nuke"}
-    + "Build EMP" station_build_weapon {"build_type": "EMP", "comms_id": comms_id, "weapon_text": "EMP"}
-    + "Build Mine" station_build_weapon {"build_type": "Mine", "comms_id": comms_id, "weapon_text": "Mine"}
-    
+    torp_keys = get_inventory_value(COMMS_SELECTED_ID, "torpedo_production_keys")
+    for t in torp_keys:
+        text = torp_get_attribute_value(t, "gui_text")
+        + "Build {text}" station_build_weapon {"build_type": t, "comms_id": comms_id, "weapon_text": text}
+    # + "Build Nuke" station_build_weapon {"build_type": "Nuke", "comms_id": comms_id, "weapon_text": "Nuke"}
+    # + "Build EMP" station_build_weapon {"build_type": "EMP", "comms_id": comms_id, "weapon_text": "EMP"}
+    # + "Build Mine" station_build_weapon {"build_type": "Mine", "comms_id": comms_id, "weapon_text": "Mine"}
+
 
 
 =============== handle_comms_station_hail  ===============
@@ -47,7 +50,7 @@ shared surrender_color = "yellow"
     station_comms_id = station_obj.name
 
     #   HOMING : 0, NUKE : 1, EMP : 2, MINE : 3
-    station_build_times = get_build_times(station_id)
+    # station_build_times = get_build_times(station_id)
     torpedo_build_type = get_inventory_value(station_id, "build_type", 0)
 
     s_max = int(get_data_set_value(COMMS_SELECTED_ID, "shield_max_val", 0))
@@ -63,6 +66,14 @@ shared surrender_color = "yellow"
     mine = get_data_set_value(COMMS_SELECTED_ID, "Mine_NUM", )
     build_time = format_time_remaining(COMMS_SELECTED_ID, "build_time")
 
+    torp_keys = get_inventory_value(station_id, "torpedo_production_keys")
+
+    stats = ""
+    for t in torp_keys:
+        count = get_data_set_value(COMMS_SELECTED_ID, f"{t}_NUM", 0)
+        time = get_build_time_for(COMMS_SELECTED_ID, t)
+        stats += """ ^{t: <10}{count: >5}{"": >16}{time}:00"""
+
     <<[green] "Hail"
         " Hello, {comms_id}.  We stand ready to assist.
         " ^Our shields are at {s_cur} / {s_max} ({s_per} %).
@@ -70,10 +81,11 @@ shared surrender_color = "yellow"
         " ^You have full docking privileges.
         " ^^{torpedo_build_type} in production. Completion in {build_time}
         " ^{"type":<10}{"ready": >5}{"time to produce": >20}
-        " ^{"Homing": <10}{homing: >5}{"": >16}{station_build_times["Homing"]}:00 
-        " ^{"Nuke": <10}{nuke: >5}{"": >16}{station_build_times["Nuke"]}:00
-        " ^{"EMP": <10}{emp: >5}{"": >16}{station_build_times["EMP"]}:00
-        " ^{"Mine": <10}{mine: >5}{"": >16}{station_build_times["Mine"]}:00
+        " {stats}
+        # " ^{"Homing": <10}{homing: >5}{"": >16}{station_build_times["Homing"]}:00 
+        # " ^{"Nuke": <10}{nuke: >5}{"": >16}{station_build_times["Nuke"]}:00
+        # " ^{"EMP": <10}{emp: >5}{"": >16}{station_build_times["EMP"]}:00
+        # " ^{"Mine": <10}{mine: >5}{"": >16}{station_build_times["Mine"]}:00
     yield success
 
 

--- a/consoles/server_console.mast
+++ b/consoles/server_console.mast
@@ -64,11 +64,15 @@ gui_reroute_clients("client_main")
     shared mission_overview = maps_get_init()
     shared WORLD_SELECT_path  = SETTINGS.get("WORLD_SELECT")
     sim_create()
-    # Create standard missile types
-    sbs.set_shared_string("Homing","gui_text:Homing;  speed:10; lifetime:25; flare_color:white; trail_color:white;warhead:standard;damage:35; explosion_size:10;explosion_color:fire; behavior:homing; energy_conversion_value:100")
-    sbs.set_shared_string("Nuke"  ,"gui_text:Nuke  ;  speed:10; lifetime:25; flare_color:white; trail_color:#99f;warhead:blast; blast_radius:1000; damage:5; explosion_size:20;explosion_color:fire; behavior:homing; energy_conversion_value:200")
-    sbs.set_shared_string("EMP"   , "gui_text:EMP  ;  speed:10; lifetime:25; flare_color:yellow; trail_color:#99f;warhead:blast,reduce_shields; blast_radius:1000; damage:50; explosion_size:20;explosion_color:#11F; behavior:homing; energy_conversion_value:50")
-    sbs.set_shared_string("Mine"  , "gui_text:Mine ;  speed:10; lifetime:25; flare_color:white; trail_color:white; warhead:blast; blast_radius:1000; damage:5; explosion_size:20; explosion_color:fire; behavior:mine; energy_conversion_value:200")
+    # Create standard missile types - NEW use prefab system
+    # sbs.set_shared_string("Homing","gui_text:Homing;  speed:10; lifetime:25; flare_color:white; trail_color:white;warhead:standard;damage:35; explosion_size:10;explosion_color:fire; behavior:homing; energy_conversion_value:100")
+    # sbs.set_shared_string("Nuke"  ,"gui_text:Nuke  ;  speed:10; lifetime:25; flare_color:white; trail_color:#99f;warhead:blast; blast_radius:1000; damage:5; explosion_size:20;explosion_color:fire; behavior:homing; energy_conversion_value:200")
+    # sbs.set_shared_string("EMP"   , "gui_text:EMP  ;  speed:10; lifetime:25; flare_color:yellow; trail_color:#99f;warhead:blast,reduce_shields; blast_radius:1000; damage:50; explosion_size:20;explosion_color:#11F; behavior:homing; energy_conversion_value:50")
+    # sbs.set_shared_string("Mine"  , "gui_text:Mine ;  speed:10; lifetime:25; flare_color:white; trail_color:white; warhead:blast; blast_radius:1000; damage:5; explosion_size:20; explosion_color:fire; behavior:mine; energy_conversion_value:200")
+    prefab_spawn(prefab_homing_torpedo)
+    prefab_spawn(prefab_mine_torpedo)
+    prefab_spawn(prefab_emp_torpedo)
+    prefab_spawn(prefab_nuclear_torpedo)
 
     #
     # Create all the player ships

--- a/consoles/server_console.mast
+++ b/consoles/server_console.mast
@@ -73,6 +73,8 @@ gui_reroute_clients("client_main")
     prefab_spawn(prefab_mine_torpedo)
     prefab_spawn(prefab_emp_torpedo)
     prefab_spawn(prefab_nuclear_torpedo)
+    # TODO: Uncomment to use Tags (they don't do anything yet!)
+    # prefab_spawn(prefab_tag_torpedo)
 
     #
     # Create all the player ships

--- a/consoles/server_console.mast
+++ b/consoles/server_console.mast
@@ -74,7 +74,7 @@ gui_reroute_clients("client_main")
     prefab_spawn(prefab_emp_torpedo)
     prefab_spawn(prefab_nuclear_torpedo)
     # TODO: Uncomment to use Tags (they don't do anything yet!)
-    # prefab_spawn(prefab_tag_torpedo)
+    prefab_spawn(prefab_tag_torpedo)
 
     #
     # Create all the player ships

--- a/docking/station_torp_building.py
+++ b/docking/station_torp_building.py
@@ -1,13 +1,11 @@
-from sbs_utils.fs import get_artemis_data_dir_filename
 from sbs_utils.procedural.roles import role
-import sbs
-from sbs_utils.procedural.query import to_id, to_object, to_blob
-from sbs_utils.procedural.execution import get_shared_variable, task_cancel, task_schedule, set_shared_variable
+from sbs_utils.procedural.query import to_id, to_object
+from sbs_utils.procedural.execution import task_cancel, task_schedule
 from sbs_utils.procedural.inventory import get_inventory_value, set_inventory_value
 
 
 
-
+# I'll leave this here for now, but this information now goes in the torpedo prefabs.
 __build_times = {
     "command": {"build_times": {"Homing": 2, "Nuke": 5, "EMP": 3, "Mine": 2}},
     "civil": {"build_times": {"Homing": 6, "Nuke": 20, "EMP": 10, "Mine": 8 }},
@@ -16,22 +14,7 @@ __build_times = {
     "default": {"build_times": {"Homing": 3, "Nuke": 10, "EMP": 5, "Mine": 4}}
 }
 
-
-def get_build_times(id_or_obj):
-    build_times = get_shared_variable("build_times", __build_times)
-    if build_times is None:
-        build_times = __build_times
-    
-    #   HOMING : 0, NUKE : 1, EMP : 2, MINE : 3
-    so = to_object(id_or_obj)
-    if so is not None:
-        artid = so.art_id
-        for k in build_times:
-            if k in artid:
-                return  build_times[k]["build_times"]
-
-    return build_times["default"]["build_times"]
-
+#TODO Should these functions be moved to sbs_utils?
 def get_torp_build_times(key):
     """
     Get the time it takes to build the torpedo with the given key at stations.
@@ -44,31 +27,13 @@ def get_torp_build_times(key):
     torp = torps.pop() # Should only be one
     return get_inventory_value(torp, "build_times")
 
-# TODO: instead of using art_id, might be better to use roles? The applicable roles would need added to shipData.yaml
 def get_build_time_for(id_or_obj, torp_type):
-    times = get_torp_build_times(torp_type)
+    # times = get_torp_build_times(torp_type)
     so = to_object(id_or_obj)
     if so is not None:
         time = get_inventory_value(so, f"{torp_type}_BUILD_SPEED", 1000)
         return time
-    return times["default"]
-
-def get_default_build_speeds(force_update:bool=False):
-    """
-    Get the defaults. Can force an update if new torp types are added dynamically later in the game
-    """
-    defaults = get_shared_variable("default_build_speeds")
-    if defaults is None or force_update:
-        # Only runs once
-        torps = role("torpedo_definition")
-        ret = {}
-        for t in torps:
-            key = get_inventory_value(t, "key")
-            default = get_inventory_value(t, "build_times")["default"]
-            ret[key] = default * 60
-        set_shared_variable("default_build_speeds", ret)
-        return ret
-    return defaults
+    return 1000
 
 
 def build_munition_queue_task(id_or_obj, torp_type):

--- a/docking/station_torp_building.py
+++ b/docking/station_torp_building.py
@@ -1,6 +1,8 @@
+from sbs_utils.fs import get_artemis_data_dir_filename
+from sbs_utils.procedural.roles import role
 import sbs
-from sbs_utils.procedural.query import to_id, to_object
-from sbs_utils.procedural.execution import get_shared_variable, task_cancel, task_schedule
+from sbs_utils.procedural.query import to_id, to_object, to_blob
+from sbs_utils.procedural.execution import get_shared_variable, task_cancel, task_schedule, set_shared_variable
 from sbs_utils.procedural.inventory import get_inventory_value, set_inventory_value
 
 
@@ -30,9 +32,43 @@ def get_build_times(id_or_obj):
 
     return build_times["default"]["build_times"]
 
+def get_torp_build_times(key):
+    """
+    Get the time it takes to build the torpedo with the given key at stations.
+    Args:
+        key (str): The key of the torpedo type
+    Returns:
+        dict: A dictionary with station types as the keys (e.g. command) and the time to build as the value.
+    """
+    torps = role(key) & role("torpedo_definition")
+    torp = torps.pop() # Should only be one
+    return get_inventory_value(torp, "build_times")
+
+# TODO: instead of using art_id, might be better to use roles? The applicable roles would need added to shipData.yaml
 def get_build_time_for(id_or_obj, torp_type):
-    bt = get_build_times(id_or_obj)
-    return bt.get(torp_type, 1000) * 60
+    times = get_torp_build_times(torp_type)
+    so = to_object(id_or_obj)
+    if so is not None:
+        time = get_inventory_value(so, f"{torp_type}_BUILD_SPEED", 1000)
+        return time
+    return times["default"]
+
+def get_default_build_speeds(force_update:bool=False):
+    """
+    Get the defaults. Can force an update if new torp types are added dynamically later in the game
+    """
+    defaults = get_shared_variable("default_build_speeds")
+    if defaults is None or force_update:
+        # Only runs once
+        torps = role("torpedo_definition")
+        ret = {}
+        for t in torps:
+            key = get_inventory_value(t, "key")
+            default = get_inventory_value(t, "build_times")["default"]
+            ret[key] = default * 60
+        set_shared_variable("default_build_speeds", ret)
+        return ret
+    return defaults
 
 
 def build_munition_queue_task(id_or_obj, torp_type):
@@ -47,7 +83,7 @@ def build_munition_queue_task(id_or_obj, torp_type):
     if build_task is not None:
         task_cancel(build_task)
     # Start the new work    
-    build_time = get_build_time_for(id_or_obj, torp_type)
+    build_time = get_build_time_for(id_or_obj, torp_type)*60
     set_inventory_value(id_or_obj, "build_task", task_schedule("task_station_building", 
         data={"station_id": to_id(id_or_obj), "build_time": build_time, "torpedo_build_type": torp_type}))
     return True

--- a/prefabs/__init__.mast
+++ b/prefabs/__init__.mast
@@ -6,3 +6,5 @@ import side_prefabs.mast
 import terrain_prefabs.mast
 import station_prefabs.mast
 import lifeform_prefabs.mast
+
+import torpedo_prefabs.mast

--- a/prefabs/torpedo_prefabs.mast
+++ b/prefabs/torpedo_prefabs.mast
@@ -32,7 +32,7 @@ lifetime: 25
 flare_color: white
 trail_color: white
 warhead: standard
-blast_radius: 1000 # blast_radius may be broken if warhead isn't "blast"
+blast_radius: 1000 # only applicable if warhead == 'blast'
 damage: 35
 explosion_size: 10
 explosion_color: fire
@@ -43,13 +43,14 @@ player_ship_roles: __player__
 build_speeds:
     industry: 3
     default: 1
-on_hit: default_torp_hit
 ```
 
     if key is None:
         yield fail
     if gui_name is None:
         gui_name = key
+    if len(role(key) & role("torpedo_definition")) > 0: # if torp already exists
+        yield fail
     default speed = 10
     default lifetime = 25
     default flare_color = "white"
@@ -84,7 +85,8 @@ on_hit: default_torp_hit
 
     roles = player_ship_roles.split(",")
     for r in roles:
-        ships = role(r) & role("__player__") # should only apply to player ships
+        ships = role(r) & role("__player__") # should only apply to existing player ships
+        print(f"Ships: {len(ships)}")
         for ship in ships:
             count,_max = torpedo_get_count_for_ship(ship, key)
             if _max == 0:
@@ -96,45 +98,35 @@ on_hit: default_torp_hit
 
     yield result id
 
-//spawn if has_role("__player__")
+# Here we handle spawning of ships, and giving them torps as determined by the torpedo's definitions.
+//spawn if has_role(SPAWNED_ID, "__player__")
+    await delay_sim(1) # Wait until all torp definitions are loaded
+    ship = SPAWNED_ID
+    jump give_custom_torps_to_players
+
+
+==== give_custom_torps_to_players
 " When player ships spawn, add custom torpedo types according to the `player_ship_roles` of the torpedoes.
-    delay_sim(5) # Ensure that ships and torp types have spawned.
+    if ship is None:
+        # print("`ship` not defined for `give_custom_torps_to_players` label.")
+        ->END
+    if to_object(ship) is None:
+        # print("Object for `ship` not found.") # This fires multiple times on startup, not sure why.
+        ->END
     torps = role("torpedo_definition")
     for tr in torps:
+        key = get_inventory_value(tr, "key")
         player_ship_roles = get_inventory_value(tr, "player_ship_roles")
         count = get_inventory_value(tr, "default_max_count")
         if player_ship_roles is not None:
             roles = player_ship_roles.split(",")
             for r in roles:
-                if has_role(SPAWNED_ID, r):
-                    cur_count, cur_max = torpedo_get_count_for_ship(SPAWNED_ID, tr)
-                    if cur_max == 0:
-                        torpedo_make_available(SPAWNED_ID, tr, count)
-
-
-#### NOTE: Because this is inefficient, I'm leaving it commented out. But I want it here for now as a reference.
-###### Probably the right thing is to use //damage/object if EVENT.sub_tag == "torp_key"
-###### Which means that the `on_hit` metadata field is probably unnecessary.
-# //damage/object
-# " This label runs anytime an object is damaged. This is probably NOT an ideal long-term solution.
-#     # TODO: Find a better way to do this?
-#     torps = role(EVENT.sub_tag) & role("torpedo_definition")
-#     if len(torps) > 0:
-#         t = torps.pop()
-#         lbl = get_inventory_value(t, "on_hit")
-#         # print(lbl)
-#         if lbl is not None:
-#             task_schedule(lbl, {"torpedo_key":t})
-#     ->END
-
-# === default_torp_hit
-# " The default behavior for a torpedo hitting an object. This is really just an example.
-# " For a custom torpedo, you want to make your own label to run, if it needs to do anything special.
-# metadata: ```
-# torpedo_key:
-# ```
-#     print(f"Torpedo hit!")
-#     ->END
+                if has_role(ship, r):
+                    counts = torpedo_get_count_for_ship(ship, key)
+                    if counts[1] == 0: # Only add if the torp isn't added already
+                        # print(f"Making {key} available: {count}")
+                        torpedo_make_available(ship, key, count)
+    ->END
 
 
 === prefab_homing_torpedo
@@ -160,7 +152,6 @@ build_speeds:
     industry: 1
     science: 6
     default: 3
-on_hit:
 ```
     jump prefab_torpedo_type
 
@@ -187,7 +178,6 @@ build_speeds:
     industry: 2
     science: 10
     default: 5
-on_hit: None
 ```
     jump prefab_torpedo_type
 
@@ -214,7 +204,6 @@ build_speeds:
     industry: 4
     science: 20
     default: 10
-on_hit: None
 ```
     jump prefab_torpedo_type
 
@@ -241,7 +230,6 @@ build_speeds:
     industry: 2
     science: 8
     default: 4
-on_hit: None
 ```
     jump prefab_torpedo_type
 
@@ -259,13 +247,14 @@ build_speeds:
     industry: 1
     science: 1
     default: 4
-on_hit: apply_tag
 ```
     jump prefab_torpedo_type
 
-#//damage/object if EVENT.sub_tag == "Tag"
-== apply_tag 
-    
+/*
+    This is an example of how to add custom functionality when a torpedo hits something.
+*/
+//damage/object if EVENT.sub_tag == "Tag"
     add_role(DAMAGE_TARGET_ID, "tagged")
+    print("Ship Tagged!")
     # TODO: Add a use for the "tagged" role.
     # TODO: May be better to use a link instead of, or in addition to, the role?

--- a/prefabs/torpedo_prefabs.mast
+++ b/prefabs/torpedo_prefabs.mast
@@ -22,7 +22,7 @@
 "
 "        player_ship_roles (str, optional): A comma-separated string of roles that should get this torpedo.
 "        energy_conversion_value (int, optional): The amount of energy to provide to the ship by disassembling the torpedo. Default is 100.
-"        build_speeds (dict, optional): A dictionary of (str, int) representing the station type and the rate of production.
+"        build_times (dict, optional): A dictionary of (str, int) representing the station type and the rate of production.
 "        on_hit (label, optional): The label to run when the torpedo hits.
 metadata: ```
 key: Homing
@@ -40,7 +40,7 @@ behavior: homing
 energy_conversion_value: 100
 default_max_count: 10
 player_ship_roles: __player__
-build_speeds:
+build_times:
     industry: 3
     default: 1
 ```
@@ -64,7 +64,7 @@ build_speeds:
     default energy_conversion_value = 100
     default default_max_count = 10
     default player_ship_roles = "__player__"
-    default build_speeds = {"default": 3, "industry": 1}
+    default build_times = {"default": 3, "industry": 1}
 
     ~~ torpedo_type(key=key, 
         gui_text=gui_name, 
@@ -94,9 +94,36 @@ build_speeds:
             torpedo_make_available(ship, key, _max)
 
     # I think this isn't necessary
-    # set_inventory_value(id, "station_build_speeds", build_speeds)
+    # set_inventory_value(id, "station_build_times", build_times)
 
     yield result id
+
+//spawn if has_role(SPAWNED_ID, "station")
+    await delay_sim(1)
+    s = SPAWNED_ID
+    jump set_station_torpedo_production_speeds
+
+=== set_station_torpedo_production_speeds
+    if s is None:
+        ->END
+    so = to_object(s)
+    if so is None:
+        ->END
+    artid = so.art_id
+    torps = role("torpedo_definition")
+    torp_keys = []
+    for tr in torps:
+        key = get_inventory_value(tr, "key")
+        torp_keys.append(key)
+        times = get_inventory_value(tr, "build_times")
+        for station_type in times:
+            if station_type in artid:
+                time = times[station_type]
+                set_inventory_value(s, f"{key}_BUILD_SPEED", time)
+                break
+    # @inventory torpedo_production_keys A list of all the keys of torpedoes this station could produce
+    set_inventory_value(s, "torpedo_production_keys", torp_keys)
+    ->END
 
 # Here we handle spawning of ships, and giving them torps as determined by the torpedo's definitions.
 //spawn if has_role(SPAWNED_ID, "__player__")
@@ -146,7 +173,7 @@ behavior: homing
 energy_conversion_value: 100
 default_max_count: 10
 player_ship_roles: tsn
-build_speeds:
+build_times:
     command: 2
     civil: 6
     industry: 1
@@ -172,7 +199,7 @@ behavior: homing
 energy_conversion_value: 50
 default_max_count: 10
 player_ship_roles: tsn
-build_speeds:
+build_times:
     command: 3
     civil: 10
     industry: 2
@@ -198,7 +225,7 @@ behavior: homing
 energy_conversion_value: 200
 default_max_count: 10
 player_ship_roles: tsn
-build_speeds:
+build_times:
     command: 5
     civil: 20
     industry: 4
@@ -224,7 +251,7 @@ behavior: mine
 energy_conversion_value: 200
 default_max_count: 10
 player_ship_roles: tsn
-build_speeds:
+build_times:
     command: 2
     civil: 8
     industry: 2
@@ -241,7 +268,7 @@ gui_name: Tag
 damage: 0
 default_max_count: 5
 player_ship_roles: tsn
-build_speeds:
+build_times:
     command: 1
     civil: 3
     industry: 1

--- a/prefabs/torpedo_prefabs.mast
+++ b/prefabs/torpedo_prefabs.mast
@@ -1,0 +1,271 @@
+# TODO: The build speed data is not yet utilized in docking.mast. 
+
+=== prefab_torpedo_type
+"        key (str): The key by which the torpodo is identified.
+"        gui_text (str, optional): The name of the torpedo as seen by the players. If None, then will be the same as the key.
+"        speed (int, optional): The speed at which the torpedo moves. Default is 10.
+"        lifetime (int, optional): How long (in seconds) the torpedo continues to move. Default is 25.
+"        flare_color (str, optional): The color of the torpedo's exhuast flare. Default is white.
+"        trail_color (str, optional): The color of the torpedo's exhaust trail. Default is white.
+"        warhead (str, optional): A comma-separated string defining the behavior of the warhead upon contact. Default is standard.
+"            * standard - the default behavior of damaging a single target upon hit.
+"            * blast - creates an area of effect with diminishing effects as the distance from the blast epicenter increases.
+"            * reduce_shields - reduces the shields of the target(s). (EMP)
+"
+"        blast_radius (int, optional): How large the area of effect should be, if `warhead` has the type "blast". Default is 1000.
+"        damage (int, optional): The base damage dealt to the target. If `warhead` has the type "blast", damage decreases depending on the distance from the blast's epicenter. Default is 5.
+"        explosion_size (int, optional): The size of the explosion visual effect on the 3d view. Default is 10.
+"        explosion_color (str, optional): The color of the explosion visual effect on the 3d view. Default is "fire".
+"        behaviour (str, optional): The behavior of the torpedo guidance system. Default is homing.
+"            * homing - the torpedo will home in on its target, compensating for movement.
+"            * mine - the torpedo will not move after it has been placed and will detonate when a ship gets close.
+"
+"        player_ship_roles (str, optional): A comma-separated string of roles that should get this torpedo.
+"        energy_conversion_value (int, optional): The amount of energy to provide to the ship by disassembling the torpedo. Default is 100.
+"        build_speeds (dict, optional): A dictionary of (str, int) representing the station type and the rate of production.
+"        on_hit (label, optional): The label to run when the torpedo hits.
+metadata: ```
+key: Homing
+gui_name: Homing
+speed: 10
+lifetime: 25
+flare_color: white
+trail_color: white
+warhead: standard
+blast_radius: 1000 # blast_radius may be broken if warhead isn't "blast"
+damage: 35
+explosion_size: 10
+explosion_color: fire
+behavior: homing
+energy_conversion_value: 100
+default_max_count: 10
+player_ship_roles: __player__
+build_speeds:
+    industry: 3
+    default: 1
+on_hit: default_torp_hit
+```
+
+    if key is None:
+        yield fail
+    if gui_name is None:
+        gui_name = key
+    default speed = 10
+    default lifetime = 25
+    default flare_color = "white"
+    default trail_color = "white"
+    default warhead = "standard"
+    default blast_radius = 1000
+    default damage = 35
+    default explosion_size = 10
+    default explosion_color = "fire"
+    default behavior = "homing"
+    default energy_conversion_value = 100
+    default default_max_count = 10
+    default player_ship_roles = "__player__"
+    default build_speeds = {"default": 3, "industry": 1}
+
+    ~~ torpedo_type(key=key, 
+        gui_text=gui_name, 
+        speed=speed, 
+        lifetime=lifetime, 
+        flare_color=flare_color, 
+        trail_color=trail_color, 
+        warhead=warhead, 
+        blast_radius=blast_radius, 
+        damage=damage, 
+        explosion_size=explosion_size, 
+        explosion_color=explosion_color, 
+        behavior=behavior, 
+        energy_conversion_value=energy_conversion_value) ~~
+    id = prefab.get_id()
+    add_role(id, "torpedo_definition")
+    add_role(id, key)
+
+    roles = player_ship_roles.split(",")
+    for r in roles:
+        ships = role(r) & role("__player__") # should only apply to player ships
+        for ship in ships:
+            count,_max = torpedo_get_count_for_ship(ship, key)
+            if _max == 0:
+                _max = default_max_count
+            torpedo_make_available(ship, key, _max)
+
+    # I think this isn't necessary
+    # set_inventory_value(id, "station_build_speeds", build_speeds)
+
+    yield result id
+
+//spawn if has_role("__player__")
+" When player ships spawn, add custom torpedo types according to the `player_ship_roles` of the torpedoes.
+    delay_sim(5) # Ensure that ships and torp types have spawned.
+    torps = role("torpedo_definition")
+    for tr in torps:
+        player_ship_roles = get_inventory_value(tr, "player_ship_roles")
+        count = get_inventory_value(tr, "default_max_count")
+        if player_ship_roles is not None:
+            roles = player_ship_roles.split(",")
+            for r in roles:
+                if has_role(SPAWNED_ID, r):
+                    cur_count, cur_max = torpedo_get_count_for_ship(SPAWNED_ID, tr)
+                    if cur_max == 0:
+                        torpedo_make_available(SPAWNED_ID, tr, count)
+
+
+#### NOTE: Because this is inefficient, I'm leaving it commented out. But I want it here for now as a reference.
+###### Probably the right thing is to use //damage/object if EVENT.sub_tag == "torp_key"
+###### Which means that the `on_hit` metadata field is probably unnecessary.
+# //damage/object
+# " This label runs anytime an object is damaged. This is probably NOT an ideal long-term solution.
+#     # TODO: Find a better way to do this?
+#     torps = role(EVENT.sub_tag) & role("torpedo_definition")
+#     if len(torps) > 0:
+#         t = torps.pop()
+#         lbl = get_inventory_value(t, "on_hit")
+#         # print(lbl)
+#         if lbl is not None:
+#             task_schedule(lbl, {"torpedo_key":t})
+#     ->END
+
+# === default_torp_hit
+# " The default behavior for a torpedo hitting an object. This is really just an example.
+# " For a custom torpedo, you want to make your own label to run, if it needs to do anything special.
+# metadata: ```
+# torpedo_key:
+# ```
+#     print(f"Torpedo hit!")
+#     ->END
+
+
+=== prefab_homing_torpedo
+metadata: ```
+key: Homing
+gui_name: Homing
+speed: 10
+lifetime: 25
+flare_color: white
+trail_color: white
+warhead: standard
+blast_radius: 1000
+damage: 35
+explosion_size: 10
+explosion_color: fire
+behavior: homing
+energy_conversion_value: 100
+default_max_count: 10
+player_ship_roles: tsn
+build_speeds:
+    command: 2
+    civil: 6
+    industry: 1
+    science: 6
+    default: 3
+on_hit:
+```
+    jump prefab_torpedo_type
+
+=== prefab_emp_torpedo
+metadata: ```
+key: EMP
+gui_name: EMP
+speed: 10
+lifetime: 25
+flare_color: yellow
+trail_color: #99f
+warhead: blast,reduce_shields
+blast_radius: 1000
+damage: 50
+explosion_size: 20
+explosion_color: #11F
+behavior: homing
+energy_conversion_value: 50
+default_max_count: 10
+player_ship_roles: tsn
+build_speeds:
+    command: 3
+    civil: 10
+    industry: 2
+    science: 10
+    default: 5
+on_hit: None
+```
+    jump prefab_torpedo_type
+
+=== prefab_nuclear_torpedo
+metadata: ```
+key: Nuke
+gui_name: Nuke
+speed: 10
+lifetime: 25
+flare_color: white
+trail_color: #99f
+warhead: blast
+blast_radius: 1000
+damage: 5
+explosion_size: 10
+explosion_color: fire
+behavior: homing
+energy_conversion_value: 200
+default_max_count: 10
+player_ship_roles: tsn
+build_speeds:
+    command: 5
+    civil: 20
+    industry: 4
+    science: 20
+    default: 10
+on_hit: None
+```
+    jump prefab_torpedo_type
+
+=== prefab_mine_torpedo
+metadata: ```
+key: Mine
+gui_name: Mine
+speed: 10
+lifetime: 25
+flare_color: white
+trail_color: white
+warhead: blast
+blast_radius: 1000
+damage: 5
+explosion_size: 20
+explosion_color: fire
+behavior: mine
+energy_conversion_value: 200
+default_max_count: 10
+player_ship_roles: tsn
+build_speeds:
+    command: 2
+    civil: 8
+    industry: 2
+    science: 8
+    default: 4
+on_hit: None
+```
+    jump prefab_torpedo_type
+
+== prefab_tag_torpedo
+" A basic implementation of the Artemis 2.8 Tag torpedo type.
+metadata: ```
+key: Tag
+gui_name: Tag
+damage: 0
+default_max_count: 5
+player_ship_roles: tsn
+build_speeds:
+    command: 1
+    civil: 3
+    industry: 1
+    science: 1
+    default: 4
+on_hit: apply_tag
+```
+    jump prefab_torpedo_type
+
+#//damage/object if EVENT.sub_tag == "Tag"
+== apply_tag 
+    
+    add_role(DAMAGE_TARGET_ID, "tagged")
+    # TODO: Add a use for the "tagged" role.
+    # TODO: May be better to use a link instead of, or in addition to, the role?

--- a/prefabs/torpedo_prefabs.mast
+++ b/prefabs/torpedo_prefabs.mast
@@ -1,5 +1,3 @@
-# TODO: The build speed data is not yet utilized in docking.mast. 
-
 === prefab_torpedo_type
 "        key (str): The key by which the torpodo is identified.
 "        gui_text (str, optional): The name of the torpedo as seen by the players. If None, then will be the same as the key.
@@ -13,17 +11,16 @@
 "            * reduce_shields - reduces the shields of the target(s). (EMP)
 "
 "        blast_radius (int, optional): How large the area of effect should be, if `warhead` has the type "blast". Default is 1000.
-"        damage (int, optional): The base damage dealt to the target. If `warhead` has the type "blast", damage decreases depending on the distance from the blast's epicenter. Default is 5.
+"        damage (int, optional): The base damage dealt to the target. If `warhead` has the type "blast", damage decreases depending on the distance from the blast's epicenter. Default is 35.
 "        explosion_size (int, optional): The size of the explosion visual effect on the 3d view. Default is 10.
 "        explosion_color (str, optional): The color of the explosion visual effect on the 3d view. Default is "fire".
 "        behaviour (str, optional): The behavior of the torpedo guidance system. Default is homing.
 "            * homing - the torpedo will home in on its target, compensating for movement.
 "            * mine - the torpedo will not move after it has been placed and will detonate when a ship gets close.
 "
-"        player_ship_roles (str, optional): A comma-separated string of roles that should get this torpedo.
+"        player_ship_roles (str, optional): A comma-separated string of roles that should get this torpedo. The `__player__` role is always necessary.
 "        energy_conversion_value (int, optional): The amount of energy to provide to the ship by disassembling the torpedo. Default is 100.
 "        build_times (dict, optional): A dictionary of (str, int) representing the station type and the rate of production.
-"        on_hit (label, optional): The label to run when the torpedo hits.
 metadata: ```
 key: Homing
 gui_name: Homing
@@ -41,10 +38,10 @@ energy_conversion_value: 100
 default_max_count: 10
 player_ship_roles: __player__
 build_times:
-    industry: 3
-    default: 1
+    industry: 1
+    default: 3
 ```
-
+    # Technically the metadata for this label is unnecessary, but I'm leaving it in place for use by the extension.
     if key is None:
         yield fail
     if gui_name is None:
@@ -86,18 +83,17 @@ build_times:
     roles = player_ship_roles.split(",")
     for r in roles:
         ships = role(r) & role("__player__") # should only apply to existing player ships
-        print(f"Ships: {len(ships)}")
+        # print(f"Ships: {len(ships)}")
         for ship in ships:
             count,_max = torpedo_get_count_for_ship(ship, key)
-            if _max == 0:
+            if _max == 0: # Only add if not already defined in shipData
                 _max = default_max_count
             torpedo_make_available(ship, key, _max)
 
-    # I think this isn't necessary
-    # set_inventory_value(id, "station_build_times", build_times)
-
     yield result id
 
+
+#region Station Spawn and Production Time Assignment
 //spawn if has_role(SPAWNED_ID, "station")
     await delay_sim(1)
     s = SPAWNED_ID
@@ -109,6 +105,7 @@ build_times:
     so = to_object(s)
     if so is None:
         ->END
+    # TODO: instead of using art_id, might be better to use roles? The applicable roles would need added to shipData.yaml
     artid = so.art_id
     torps = role("torpedo_definition")
     torp_keys = []
@@ -120,12 +117,18 @@ build_times:
             if station_type in artid:
                 time = times[station_type]
                 set_inventory_value(s, f"{key}_BUILD_SPEED", time)
+                if get_data_set_value(s, f"{key}_NUM") is None: # If it's not already set, set it.
+                    set_data_set_value(s, f"{key}_NUM", random.randrange(0,3)) 
                 break
     # @inventory torpedo_production_keys A list of all the keys of torpedoes this station could produce
     set_inventory_value(s, "torpedo_production_keys", torp_keys)
+    set_data_set_value(s, "torpedo_types_available", ",".join(torp_keys))
     ->END
 
+#endregion
+
 # Here we handle spawning of ships, and giving them torps as determined by the torpedo's definitions.
+#region Player Ship Torp Assignment
 //spawn if has_role(SPAWNED_ID, "__player__")
     await delay_sim(1) # Wait until all torp definitions are loaded
     ship = SPAWNED_ID
@@ -154,7 +157,7 @@ build_times:
                         # print(f"Making {key} available: {count}")
                         torpedo_make_available(ship, key, count)
     ->END
-
+#endregion
 
 === prefab_homing_torpedo
 metadata: ```
@@ -266,6 +269,7 @@ metadata: ```
 key: Tag
 gui_name: Tag
 damage: 0
+explosion_size: 1
 default_max_count: 5
 player_ship_roles: tsn
 build_times:


### PR DESCRIPTION
Torpedoes now use the prefab system.

Major modification to make torpedoes more extensible. Now it's very easy to add a new torpedo type, including adding custom functionality upon a torpedo (or mine) hitting a target. See prefab_tag_torpedo as an example.

Changed how build speed is stored. Used to be a hardcoded dictionary. Now the build speeds are defined on the torpedo prefab objects using `set_inventory_value(s, f"{key}_BUILD_SPEED", time)` to mirror the blob data that tracks the current number and maximum. As a side effect, this allows for modifiers to apply to the build speed! (Though changes are needed to how times are displayed in the comms messages to support this)